### PR TITLE
Implement g wt switch for worktree switching

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,4 +63,19 @@ pub enum WorktreeCommands {
         #[arg(help = "Branch name")]
         branch: String,
     },
+
+    #[command(about = "Switch to a worktree")]
+    Switch {
+        #[arg(help = "Branch name")]
+        branch: Option<String>,
+
+        #[arg(short, long, help = "Interactive selection with fzf")]
+        interactive: bool,
+
+        #[arg(short, long, help = "Create new worktree and switch to it")]
+        create: bool,
+
+        #[arg(long, help = "Base branch for new branch (used with --create)")]
+        base: Option<String>,
+    },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ fn main() -> Result<()> {
 
             match cmd {
                 WorktreeCommands::Create { branch, base } => {
-                    worktree::create_worktree(&repo_info, &branch, base.as_deref())?;
+                    let _ = worktree::create_worktree(&repo_info, &branch, base.as_deref())?;
                 }
                 WorktreeCommands::List => {
                     worktree::list_worktrees(&repo_info)?;
@@ -37,6 +37,20 @@ fn main() -> Result<()> {
                 }
                 WorktreeCommands::ForceDelete { branch } => {
                     worktree::delete_worktree(&repo_info, &branch, true)?;
+                }
+                WorktreeCommands::Switch {
+                    branch,
+                    interactive,
+                    create,
+                    base,
+                } => {
+                    worktree::switch_worktree(
+                        &repo_info,
+                        branch.as_deref(),
+                        interactive,
+                        create,
+                        base.as_deref(),
+                    )?;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Add `g wt switch` command with multiple modes
- Support interactive selection with fzf
- Support direct branch switching
- Support create-and-switch workflow

## Changes
- Add `Switch` command to `WorktreeCommands` enum with options:
  - `branch`: optional branch name
  - `-i/--interactive`: fzf selection mode
  - `-c/--create`: create new worktree and switch
  - `--base`: base branch for new branch
- Implement `switch_worktree()` function
- Modify `create_worktree()` to return `PathBuf` for shell integration
- Output worktree path to stdout for shell wrapper

## Test plan
- [x] All tests pass (15 tests)
- [x] Code formatting check passes
- [x] Clippy lints pass

Closes #13

🤖 Generated with [Claude Code](https://claude.ai/code)