### PR TITLE
Implement g switch for interactive branch switching

### DIFF
--- a/src/branch.rs
+++ b/src/branch.rs
@@ -1,0 +1,80 @@
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+use std::process::Command;
+
+pub fn switch_branch(
+    repo_root: &PathBuf,
+    branch: Option<&str>,
+    interactive: bool,
+    args: &[String],
+) -> Result<()> {
+    if interactive {
+        let branches = get_branches(repo_root)?;
+
+        let opts = crate::fzf::FzfOptions {
+            prompt: Some("Select branch: ".to_string()),
+            preview: Some("git log {} -n 10 --oneline --color=always".to_string()),
+            ..Default::default()
+        };
+
+        if let Some(selection) = crate::fzf::run_fzf(&branches, Some(opts))? {
+            let branch_name = selection.trim();
+
+            let status = Command::new("git")
+                .args(["switch", branch_name])
+                .current_dir(repo_root)
+                .status()
+                .context("Failed to execute git switch")?;
+
+            if !status.success() {
+                anyhow::bail!("git switch failed");
+            }
+
+            println!("Switched to branch '{}'", branch_name);
+        }
+
+        return Ok(());
+    }
+
+    let mut cmd = Command::new("git");
+    cmd.arg("switch");
+
+    if let Some(branch_name) = branch {
+        cmd.arg(branch_name);
+    }
+
+    cmd.args(args);
+
+    let status = cmd
+        .current_dir(repo_root)
+        .status()
+        .context("Failed to execute git switch")?;
+
+    if !status.success() {
+        anyhow::bail!("git switch failed");
+    }
+
+    Ok(())
+}
+
+fn get_branches(repo_root: &PathBuf) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["branch", "--format=%(refname:short)"])
+        .current_dir(repo_root)
+        .output()
+        .context("Failed to execute git branch")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("git branch failed: {}", stderr);
+    }
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let branches: Vec<String> = stdout
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    Ok(branches)
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -23,6 +23,18 @@ pub enum Commands {
         #[command(subcommand)]
         cmd: WorktreeCommands,
     },
+
+    #[command(about = "Switch branches (git switch wrapper)")]
+    Switch {
+        #[arg(help = "Branch name")]
+        branch: Option<String>,
+
+        #[arg(short, long, help = "Interactive selection with fzf")]
+        interactive: bool,
+
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        args: Vec<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod branch;
 mod cli;
 mod fzf;
 mod git;
@@ -53,6 +54,14 @@ fn main() -> Result<()> {
                     )?;
                 }
             }
+        }
+        Commands::Switch {
+            branch,
+            interactive,
+            args,
+        } => {
+            let repo_info = repo::RepoInfo::detect()?;
+            branch::switch_branch(&repo_info.repo_root, branch.as_deref(), interactive, &args)?;
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `g switch` command as git switch wrapper
- Support interactive branch selection with fzf
- Support all standard git switch options

## Changes
- Add `Switch` command to root `Commands` enum
- New `src/branch.rs` module with:
  - `switch_branch()` for branch switching logic
  - `get_branches()` to list local branches
- Support `-i/--interactive` for fzf mode
- Support trailing args for git switch options passthrough
- Include git log preview in fzf selection

## Test plan
- [x] All tests pass (15 tests)
- [x] Code formatting check passes
- [x] Clippy lints pass

Closes #14

🤖 Generated with [Claude Code](https://claude.ai/code)