### PR TITLE
feat: change fzf default height to 100% for better visibility

### DIFF
--- a/.gitconfig.example
+++ b/.gitconfig.example
@@ -1,0 +1,52 @@
+# Sonic Git Configuration Example
+#
+# Copy these settings to your ~/.gitconfig or run the commands below:
+
+[sonic-git]
+	# Repository root directory (default: $HOME/src)
+	# NOTE: Use full path, not ~
+	root = /Users/yourusername/src
+
+[sonic-git "alias"]
+	# Repository management
+	rc = sonic-repository clone
+	rs = sonic-repository switch -i
+	rd = sonic-repository delete -i
+	rn = sonic-repository new
+
+	# Switch (branch switching with fzf)
+	s = sonic-switch
+	si = sonic-switch -i
+
+	# Branch management
+	bl = sonic-branch ls
+	bn = sonic-branch new
+	bm = sonic-branch mv
+	bd = sonic-branch delete
+
+	# Worktree management
+	wtn = sonic-worktree new
+	wtl = sonic-worktree ls
+	wtm = sonic-worktree mv
+	wts = sonic-worktree switch
+	wtsi = sonic-worktree switch -i
+	wtd = sonic-worktree delete
+
+# To apply these settings, run:
+#   git config --global sonic-git.root "$HOME/src"
+#   git config --global sonic-git.alias.rc "sonic-repository clone"
+#   git config --global sonic-git.alias.rs "sonic-repository switch -i"
+#   git config --global sonic-git.alias.rd "sonic-repository delete -i"
+#   git config --global sonic-git.alias.rn "sonic-repository new"
+#   git config --global sonic-git.alias.s "sonic-switch"
+#   git config --global sonic-git.alias.si "sonic-switch -i"
+#   git config --global sonic-git.alias.bl "sonic-branch ls"
+#   git config --global sonic-git.alias.bn "sonic-branch new"
+#   git config --global sonic-git.alias.bm "sonic-branch mv"
+#   git config --global sonic-git.alias.bd "sonic-branch delete"
+#   git config --global sonic-git.alias.wtn "sonic-worktree new"
+#   git config --global sonic-git.alias.wtl "sonic-worktree ls"
+#   git config --global sonic-git.alias.wtm "sonic-worktree mv"
+#   git config --global sonic-git.alias.wts "sonic-worktree switch"
+#   git config --global sonic-git.alias.wtsi "sonic-worktree switch -i"
+#   git config --global sonic-git.alias.wtd "sonic-worktree delete"

--- a/install-config.sh
+++ b/install-config.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Sonic Git Configuration Installer
+# This script installs recommended aliases to your global git config
+
+echo "Installing Sonic Git configuration..."
+
+# Set repository root
+git config --global sonic-git.root "$HOME/src"
+
+# Repository aliases
+git config --global sonic-git.alias.rc "sonic-repository clone"
+git config --global sonic-git.alias.rs "sonic-repository switch -i"
+git config --global sonic-git.alias.rd "sonic-repository delete -i"
+git config --global sonic-git.alias.rn "sonic-repository new"
+
+# Switch aliases
+git config --global sonic-git.alias.s "sonic-switch"
+git config --global sonic-git.alias.si "sonic-switch -i"
+
+# Branch aliases
+git config --global sonic-git.alias.bl "sonic-branch ls"
+git config --global sonic-git.alias.bn "sonic-branch new"
+git config --global sonic-git.alias.bm "sonic-branch mv"
+git config --global sonic-git.alias.bd "sonic-branch delete"
+
+# Worktree aliases
+git config --global sonic-git.alias.wtn "sonic-worktree new"
+git config --global sonic-git.alias.wtl "sonic-worktree ls"
+git config --global sonic-git.alias.wtm "sonic-worktree mv"
+git config --global sonic-git.alias.wts "sonic-worktree switch"
+git config --global sonic-git.alias.wtsi "sonic-worktree switch -i"
+git config --global sonic-git.alias.wtd "sonic-worktree delete"
+
+echo "✓ Configuration installed successfully!"
+echo ""
+echo "Try these commands:"
+echo "  g si          # sonic-switch -i (interactive branch switch)"
+echo "  g rs          # sonic-repository switch -i (switch repository)"
+echo "  g bn feat     # sonic-branch new feat (create branch)"
+echo "  g wtsi        # sonic-worktree switch -i (switch worktree)"
+echo ""
+echo "View all aliases:"
+echo "  git config --get-regexp sonic-git.alias"

--- a/src/fzf.rs
+++ b/src/fzf.rs
@@ -14,7 +14,7 @@ pub struct FzfOptions {
 impl Default for FzfOptions {
     fn default() -> Self {
         Self {
-            height: Some("40%".to_string()),
+            height: Some("100%".to_string()),
             reverse: true,
             border: true,
             prompt: None,


### PR DESCRIPTION
## Summary

Improved UX by making fzf selections fullscreen:
- Changed `FzfOptions` default height from `40%` to `100%`
- Affects all interactive selections (repository/branch/worktree)
- Better visibility with more items shown at once

Also added configuration files:
- `.gitconfig.example`: Manual configuration reference
- `install-config.sh`: One-command installer for recommended aliases

## Changes

### src/fzf.rs
- `height: Some("40%")` → `height: Some("100%")`

### New files
- `.gitconfig.example`: Example config with all aliases from command-list.md
- `install-config.sh`: Automated installer script

## Test Plan

- [x] Built and tested locally with `g rs`, `g si`, `g wtsi`
- [x] Fullscreen display confirmed
- [x] All 17 tests still passing

## Screenshots

Before: 11 lines visible (40% height)
After: Full terminal height

🤖 Generated with [Claude Code](https://claude.ai/code)